### PR TITLE
Change DataFrame to List for invalid field/value data to match Excel …

### DIFF
--- a/common.R
+++ b/common.R
@@ -45,7 +45,7 @@ ValidateOption <- function(dataset_contents, field) {
   }
   
   if (length(invalid_values) > 0) {
-    incorrect <- data.frame(
+    incorrect <- list(
       column = field$field, 
       invalid_value = invalid_values
     )
@@ -89,7 +89,7 @@ ValidateNumeric <- function(dataset_contents, field) {
   }
   
   if (length(invalid_content) > 0) {
-    incorrect <- data.frame(
+    incorrect <- list(
       column = field$field, 
       invalid_value = invalid_content
     )
@@ -135,7 +135,7 @@ ValidateString <- function(dataset_contents, field) {
   }
   
   if (length(invalid_value) > 0) {
-    incorrect <- data.frame(
+    incorrect <- list(
       column = field$field, 
       invalid_value = invalid_value
     )


### PR DESCRIPTION
…file parsing logic

# Prologue

While investigating issue #7, I was unable to reproduce the reported error. Instead, I encountered a hard exception when running the provided files. This PR addresses that exception and includes a fix.

# Summary

When validating the file [problem_df.csv](https://github.com/user-attachments/files/23555127/problem_df.csv), the following warnings were emitted:
```
Warning in names(df) == column_name :
  longer object length is not a multiple of shorter object length
Warning: Error in [[: Can't extract column with `col_index`.
```

followed by this exception:

```
Subscript `col_index` must be size 1, not 16.
```

After investigating, I found that the highlight_entries variable was not structured correctly for how it was being parsed. To resolve this, I updated how validation data is stored by changing the DataFrame to a List within field validation. After this change, the warnings and exception no longer occur, and the Excel file can be downloaded successfully with invalid fields correctly highlighted in yellow.

## Open Questions

There are a few errors present in the sample CSV file that do not appear to be fully reflected in the generated Excel output. For example, in the second column, the empty field error is reported in the UI, but other invalid fields are not highlighted in the Excel file. Is this the expected behavior?

Additionally, while the generated Excel file appears correct to me, I would appreciate a second review to confirm the output matches expectations. Once confirmed, I will add test cases and proceed with merging this PR. 