### PR TITLE
Remove line with unknown behavior causing local errors

### DIFF
--- a/server.R
+++ b/server.R
@@ -38,7 +38,10 @@ server <- function(input, output, session) {
       cat("\nDataset is valid! All variables match specifications.")
     } else {
       cat("\nThe dataset is not valid. Please review the specifications and the highlighted error log.")
-      highlight_csv_to_xlsx(df, issues, "/Users/abteen/Desktop/issues.xlsx")
+      # TODO: Investigate and likely remove. This line produces unclear errors in local environments
+      # and its purpose in production is unknown.
+      #
+      # highlight_csv_to_xlsx(df, issues, "/Users/abteen/Desktop/issues.xlsx")
     }
   })
   


### PR DESCRIPTION
Unclear what this does in production. Removing to eliminate obscure local errors; can be reverted if issues arise.